### PR TITLE
Fix controller leak and remove debug print

### DIFF
--- a/packages/grpc_logger_extention/lib/controllers/grpc_calls_controller.dart
+++ b/packages/grpc_logger_extention/lib/controllers/grpc_calls_controller.dart
@@ -64,7 +64,6 @@ class GrpcCallsController extends ChangeNotifier
 
     _isSearching = true;
     super.notifyListeners();
-    print(_filteredGrpcCallsList.length);
   }
 
   @override

--- a/packages/grpc_logger_extention/lib/main.dart
+++ b/packages/grpc_logger_extention/lib/main.dart
@@ -22,6 +22,12 @@ class _GRPCLoggerDevToolsExtensionState
   final GrpcCallsController grpcCallsController = GrpcCallsController();
 
   @override
+  void dispose() {
+    grpcCallsController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return DevToolsExtension(
       child: GRPCLoggerDevToolsExtensionBody(


### PR DESCRIPTION
## Summary
- dispose `GrpcCallsController` in the DevTools extension to avoid leak
- remove leftover debug print from `GrpcCallsController.search`

## Testing
- ❌ `dart pub get` *(fails: `dart` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684001386fc48333be060f1e80195f27